### PR TITLE
Support rocksDB wallet/chain compression on all architectures (no AVX2 instruction set required)

### DIFF
--- a/Discreet/DB/DisDB.cs
+++ b/Discreet/DB/DisDB.cs
@@ -193,18 +193,18 @@ namespace Discreet.DB
 
                 var _colFamilies = new ColumnFamilies
                 {
-                    new ColumnFamilies.Descriptor(SPENT_KEYS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(TX_POOL_BLOB, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(TX_POOL_SPENT_KEYS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(OUTPUTS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(TX_INDICES, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(TXS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(BLOCK_HEIGHTS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(BLOCKS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(META, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(OUTPUT_INDICES, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(BLOCK_CACHE, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(BLOCK_HEADERS, new ColumnFamilyOptions().SetCompression(Compression.No)),
+                    new ColumnFamilies.Descriptor(SPENT_KEYS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(TX_POOL_BLOB, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(TX_POOL_SPENT_KEYS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(OUTPUTS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(TX_INDICES, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(TXS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(BLOCK_HEIGHTS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(BLOCKS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(META, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(OUTPUT_INDICES, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(BLOCK_CACHE, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(BLOCK_HEADERS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
                 };
 
                 db = RocksDb.Open(options, path, _colFamilies);

--- a/Discreet/Discreet.csproj
+++ b/Discreet/Discreet.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cryptography.ECDSA.Secp256K1" Version="1.1.3" />
-    <PackageReference Include="RocksDB" Version="6.26.0.23332" />
+    <PackageReference Include="RocksDB" Version="7.1.1.28414" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 

--- a/Discreet/Wallets/WalletDB.cs
+++ b/Discreet/Wallets/WalletDB.cs
@@ -98,14 +98,14 @@ namespace Discreet.Wallets
 
             var _colFamilies = new ColumnFamilies
                 {
-                    new ColumnFamilies.Descriptor(UTXOS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(STORAGE, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(WALLETS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(WALLET_ADDRESSES, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(WALLET_HEIGHTS, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(ADDRESS_BOOK, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(TX_HISTORY, new ColumnFamilyOptions().SetCompression(Compression.No)),
-                    new ColumnFamilies.Descriptor(META, new ColumnFamilyOptions().SetCompression(Compression.No))
+                    new ColumnFamilies.Descriptor(UTXOS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(STORAGE, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(WALLETS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(WALLET_ADDRESSES, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(WALLET_HEIGHTS, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(ADDRESS_BOOK, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(TX_HISTORY, new ColumnFamilyOptions().SetCompression(Compression.Lz4)),
+                    new ColumnFamilies.Descriptor(META, new ColumnFamilyOptions().SetCompression(Compression.Lz4))
                 };
 
             db = RocksDb.Open(options, path, _colFamilies);


### PR DESCRIPTION
Addresses an issue where we had to leave the blockchain uncompressed in RocksDB because any computer running a pre-2013 (Haswell) processor would fail, because it didn't support AVX2.