### PR TITLE
improve connection behavior

### DIFF
--- a/Discreet/Network/Handler.cs
+++ b/Discreet/Network/Handler.cs
@@ -371,6 +371,16 @@ namespace Discreet.Network
                     mCache.BadVersions.Remove(conn.Receiver, out _);
                 }
 
+                Peerbloom.Connection _dupe = _network.GetPeer(new IPEndPoint(conn.Receiver.Address, conn.Port));
+
+                if (_dupe != null)
+                {
+                    // duplicate connection; end
+                    Daemon.Logger.Warn($"Discreet.Network.Handler.HandleVersion: duplicate peer connection found for {conn.Receiver} (currently at {_dupe.Receiver}); ending connection");
+                    await conn.Disconnect(true, Core.Packets.Peerbloom.DisconnectCode.CLEAN);
+                    return;
+                }
+
                 if (!mCache.Versions.TryAdd(conn.Receiver, p))
                 {
                     Daemon.Logger.Error($"Discreet.Network.Handler.HandleVersion: failed to add version for {conn.Receiver}");

--- a/Discreet/Network/Peerbloom/Connection.cs
+++ b/Discreet/Network/Peerbloom/Connection.cs
@@ -329,6 +329,15 @@ namespace Discreet.Network.Peerbloom
                             }
 
                             Daemon.Logger.Debug($"Connection.Connect: received version from {Receiver}");
+                            Connection _dupe = _network.GetPeer(new IPEndPoint(Receiver.Address, Port));
+
+                            if (!feeler && _dupe != null)
+                            {
+                                // duplicate connection; end
+                                Daemon.Logger.Warn($"Connection.Connect: duplicate peer connection found for {Receiver} (currently at {_dupe.Receiver}); ending connection");
+                                await Disconnect(true, Core.Packets.Peerbloom.DisconnectCode.CLEAN);
+                                return false;
+                            }
 
 
                             /* time to send VerAck. At this point we can trust the connection is reliable. */
@@ -958,6 +967,8 @@ namespace Discreet.Network.Peerbloom
                 {
                     Daemon.Logger.Error($"Connection.Disconnect: could not send disconnect packet to peer {Receiver}");
                 }
+                // delay the disconnect to ensure the packet reaches the peer
+                await Task.Delay(500);
             }
 
             Dispose();


### PR DESCRIPTION
- change disconnect delay to 500 ms
- If an incoming connection shares the same endpoint with an already connected peer, dispose of the connection
- if an incoming connection shares the same IP address and declared port as an already connected peer, disconnect
- if an outgoing connection shares the same IP address and declared port as an already connected peer, disconnect