### PR TITLE
Patch/handler improvements

### DIFF
--- a/Discreet/Network/Handler.cs
+++ b/Discreet/Network/Handler.cs
@@ -195,11 +195,11 @@ namespace Discreet.Network
             {
                 case PacketType.GETBLOCKS:
                 case PacketType.SENDTX:
-                case PacketType.SENDBLOCK:
                 case PacketType.GETTXS:
                 case PacketType.TXS:
                 case PacketType.BLOCKS:
                     return true;
+                case PacketType.SENDBLOCK:
                 case PacketType.ALERT:
                 case PacketType.NONE:
                 case PacketType.INVENTORY:

--- a/Discreet/Network/Handler.cs
+++ b/Discreet/Network/Handler.cs
@@ -146,7 +146,8 @@ namespace Discreet.Network
                 // execute each packet handler
                 foreach (var pritem in proute)
                 {
-                    _ = Task.Run(() => Handle(new List<Packet>(pritem.Value), pritem.Key), token).ConfigureAwait(false);
+                    var prlist = new List<Packet>(pritem.Value);
+                    _ = Task.Run(() => Handle(prlist, pritem.Key), token).ConfigureAwait(false);
                 }
 
                 foreach (var packet in parallel)
@@ -156,7 +157,8 @@ namespace Discreet.Network
 
                 if (sequential.Count > 0)
                 {
-                    _ = Task.Run(() => Handle(new List<(Packet, Peerbloom.Connection)>(sequential)), token).ConfigureAwait(false);
+                    var seqlist = new List<(Packet, Peerbloom.Connection)>(sequential);
+                    _ = Task.Run(() => Handle(seqlist), token).ConfigureAwait(false);
                 }
 
                 // clear the routed packet structures

--- a/Discreet/Network/Handler.cs
+++ b/Discreet/Network/Handler.cs
@@ -146,7 +146,7 @@ namespace Discreet.Network
                 // execute each packet handler
                 foreach (var pritem in proute)
                 {
-                    _ = Task.Run(() => Handle(pritem.Value, pritem.Key), token).ConfigureAwait(false);
+                    _ = Task.Run(() => Handle(new List<Packet>(pritem.Value), pritem.Key), token).ConfigureAwait(false);
                 }
 
                 foreach (var packet in parallel)
@@ -156,7 +156,7 @@ namespace Discreet.Network
 
                 if (sequential.Count > 0)
                 {
-                    _ = Task.Run(() => Handle(sequential), token).ConfigureAwait(false);
+                    _ = Task.Run(() => Handle(new List<(Packet, Peerbloom.Connection)>(sequential)), token).ConfigureAwait(false);
                 }
 
                 // clear the routed packet structures

--- a/Discreet/Network/Peerbloom/Connection.cs
+++ b/Discreet/Network/Peerbloom/Connection.cs
@@ -347,6 +347,13 @@ namespace Discreet.Network.Peerbloom
 
                             var verAck = await ReadAsync(token);
 
+                            if (verAck == null)
+                            {
+                                Daemon.Logger.Error($"Connection.Connect: Could not retrieve VERACK from {Receiver}");
+                                numConnectionAttempts++;
+                                continue;
+                            }
+
                             if (verAck.Header.Command != Core.PacketType.VERACK)
                             {
                                 Daemon.Logger.Error($"Connection.Connect: packet type mismatch from {Receiver}: Expected VERACK; got {verAck.Header.Command}");


### PR DESCRIPTION
- check if verack packet is null in Connection.Connect()
- create shallow copies of lists prior to clearing for Handler.Handle() (routing)