### PR TITLE
Patch/network improvements

### DIFF
--- a/Discreet/Network/Core/Packet.cs
+++ b/Discreet/Network/Core/Packet.cs
@@ -109,6 +109,10 @@ namespace Discreet.Network.Core
                     return new Packets.GetBlocksPacket(data, offset);
                 case PacketType.BLOCKS:
                     return new Packets.BlocksPacket(data, offset);
+                case PacketType.GETHEADERS:
+                    return new Packets.GetHeadersPacket(data, offset);
+                case PacketType.HEADERS:
+                    return new Packets.HeadersPacket(data, offset);
                 case PacketType.GETTXS:
                     return new Packets.GetTransactionsPacket(data, offset);
                 case PacketType.TXS:
@@ -158,6 +162,10 @@ namespace Discreet.Network.Core
                     return new Packets.GetBlocksPacket(s);
                 case PacketType.BLOCKS:
                     return new Packets.BlocksPacket(s);
+                case PacketType.GETHEADERS:
+                    return new Packets.GetHeadersPacket(s);
+                case PacketType.HEADERS:
+                    return new Packets.HeadersPacket(s);
                 case PacketType.GETTXS:
                     return new Packets.GetTransactionsPacket(s);
                 case PacketType.TXS:

--- a/Discreet/Network/Core/PacketType.cs
+++ b/Discreet/Network/Core/PacketType.cs
@@ -20,10 +20,11 @@ namespace Discreet.Network.Core
         BLOCKS = 5,
         GETTXS = 6,
         TXS = 7,
+        GETHEADERS = 9,
+        HEADERS = 10,
 
         /* currently unused for testnet */
-        //GETHEADERS = 9,
-        //HEADERS = 10,
+
         //GETTXSINBLOCK = 11, 
 
         NOTFOUND = 12,

--- a/Discreet/Network/Core/Packets/GetHeadersPacket.cs
+++ b/Discreet/Network/Core/Packets/GetHeadersPacket.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discreet.Network.Core.Packets
+{
+    public class GetHeadersPacket : IPacketBody
+    {
+        public long StartingHeight { get; set; }
+        public uint Count { get; set; }
+        public Cipher.SHA256[] Headers { get; set; }
+
+        public GetHeadersPacket()
+        {
+
+        }
+
+        public GetHeadersPacket(byte[] b, uint offset)
+        {
+            Deserialize(b, offset);
+        }
+
+        public GetHeadersPacket(Stream s)
+        {
+            Deserialize(s);
+        }
+
+        public void Deserialize(byte[] b, uint offset)
+        {
+            StartingHeight = Coin.Serialization.GetInt64(b, offset);
+            offset += 8;
+
+            Count = Coin.Serialization.GetUInt32(b, offset);
+            offset += 4;
+
+            int headersLen = Coin.Serialization.GetInt32(b, offset);
+            offset += 4;
+
+            Headers = new Cipher.SHA256[headersLen];
+
+            for (int i = 0; i < headersLen; i++)
+            {
+                Headers[i] = new Cipher.SHA256(b, offset);
+                offset += 32;
+            }
+        }
+
+        public void Deserialize(Stream s)
+        {
+            StartingHeight = Coin.Serialization.GetInt64(s);
+            Count = Coin.Serialization.GetUInt32(s);
+
+            int headersLen = Coin.Serialization.GetInt32(s);
+            Headers = new Cipher.SHA256[headersLen];
+
+            for (int i = 0; i < headersLen; i++)
+            {
+                Headers[i] = new Cipher.SHA256(s);
+            }
+        }
+
+        public uint Serialize(byte[] b, uint offset)
+        {
+            Coin.Serialization.CopyData(b, offset, StartingHeight);
+            offset += 8;
+
+            Coin.Serialization.CopyData(b, offset, Count);
+            offset += 4;
+
+            Coin.Serialization.CopyData(b, offset, Headers == null ? 0 : Headers.Length);
+            offset += 4;
+
+            if (Headers != null)
+            {
+                foreach (Cipher.SHA256 h in Headers)
+                {
+                    Array.Copy(h.Bytes, 0, b, offset, 32);
+                    offset += 32;
+                }
+            }
+
+            return offset;
+        }
+
+        public void Serialize(Stream s)
+        {
+            Coin.Serialization.CopyData(s, StartingHeight);
+            Coin.Serialization.CopyData(s, Count);
+            Coin.Serialization.CopyData(s, Headers == null ? 0 : Headers.Length);
+
+            if (Headers != null)
+            {
+                foreach (Cipher.SHA256 h in Headers)
+                {
+                    s.Write(h.Bytes);
+                }
+            }
+        }
+
+        public int Size()
+        {
+            return 16 + ((Headers == null) ? 0 : 32 * Headers.Length);
+        }
+    }
+}

--- a/Discreet/Network/Core/Packets/HeadersPacket.cs
+++ b/Discreet/Network/Core/Packets/HeadersPacket.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discreet.Network.Core.Packets
+{
+    internal class HeadersPacket: IPacketBody
+    {
+        public uint Count { get; set; }
+        public Coin.BlockHeader[] Headers { get; set; }
+
+        public HeadersPacket()
+        {
+
+        }
+
+        public HeadersPacket(byte[] b, uint offset)
+        {
+            Deserialize(b, offset);
+        }
+
+        public HeadersPacket(Stream s)
+        {
+            Deserialize(s);
+        }
+
+        public void Deserialize(byte[] b, uint offset)
+        {
+            Count = Coin.Serialization.GetUInt32(b, offset);
+            offset += 4;
+
+            Headers = new Coin.BlockHeader[Count];
+            for (int i = 0; i < Count; i++)
+            {
+                Headers[i] = new Coin.BlockHeader();
+                offset = Headers[i].Deserialize(b, offset);
+            }
+        }
+
+        public void Deserialize(Stream s)
+        {
+            using MemoryStream _ms = new MemoryStream();
+
+            byte[] buf = new byte[4096];
+            int bytesRead;
+
+            while ((bytesRead = s.Read(buf, 0, buf.Length)) > 0)
+            {
+                _ms.Write(buf, 0, bytesRead);
+            }
+
+            Deserialize(_ms.ToArray(), 0);
+        }
+
+        public uint Serialize(byte[] b, uint offset)
+        {
+            Coin.Serialization.CopyData(b, offset, Count);
+            offset += 4;
+
+            for (int i = 0; i < Count; i++)
+            {
+                Headers[i].Serialize(b, offset);
+                offset += Headers[i].Size();
+            }
+
+            return offset;
+        }
+
+        public void Serialize(Stream s)
+        {
+            s.Write(Coin.Serialization.UInt32(Count));
+
+            foreach (Coin.BlockHeader header in Headers)
+            {
+                s.Write(header.Serialize());
+            }
+        }
+
+        public int Size()
+        {
+            int rv = 4;
+
+            foreach (Coin.BlockHeader header in Headers)
+            {
+                rv += (int)header.Size();
+            }
+
+            return rv;
+        }
+    }
+}

--- a/Discreet/Network/Core/Packets/HeadersPacket.cs
+++ b/Discreet/Network/Core/Packets/HeadersPacket.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Discreet.Network.Core.Packets
 {
-    internal class HeadersPacket: IPacketBody
+    public class HeadersPacket: IPacketBody
     {
         public uint Count { get; set; }
         public Coin.BlockHeader[] Headers { get; set; }

--- a/Discreet/Network/Core/Packets/InventoryVector.cs
+++ b/Discreet/Network/Core/Packets/InventoryVector.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Discreet.Cipher.Extensions.ByteArrayExtensions;
 
 namespace Discreet.Network.Core.Packets
 {
@@ -10,5 +12,50 @@ namespace Discreet.Network.Core.Packets
     {
         public ObjectType Type;
         public Cipher.SHA256 Hash;
+
+        public InventoryVector(ObjectType type, Cipher.SHA256 hash) { this.Type = type; this.Hash = hash; }
+
+        public InventoryVector(ObjectType type, long hash) { this.Type = type; this.Hash = new Cipher.SHA256(hash); }
+
+        public byte[] Serialize()
+        {
+            byte[] rv = new byte[36];
+            Coin.Serialization.CopyData(rv, 0, (uint)Type);
+            Array.Copy(Hash.Bytes, 0, rv, 4, 32);
+
+            return rv;
+        }
+
+        public int Compare(InventoryVector y)
+        {
+            int tcmp = ((uint)Type).CompareTo((uint)y.Type);
+            if (tcmp == 0)
+            {
+                return Hash.Bytes.Compare(y.Hash.Bytes);
+            }
+
+            return tcmp;
+        }
+
+        public static bool operator ==(InventoryVector x, InventoryVector y) => x.Type == y.Type && x.Hash.Bytes.BEquals(y.Hash.Bytes);
+        public static bool operator !=(InventoryVector x, InventoryVector y) => !(x == y);
+    }
+
+    public class InventoryVectorComparer : IComparer<InventoryVector>
+    {
+        public int Compare(InventoryVector x, InventoryVector y)
+        {
+            return x.Compare(y);
+        }
+
+        public bool Equals(InventoryVector x, InventoryVector y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode([DisallowNull] InventoryVector obj)
+        {
+            return Coin.Serialization.GetInt32(Cipher.SHA256.HashData(obj.Serialize()).Bytes, 0);
+        }
     }
 }

--- a/Discreet/Network/MessageCache.cs
+++ b/Discreet/Network/MessageCache.cs
@@ -30,6 +30,7 @@ namespace Discreet.Network
         public ConcurrentDictionary<IPEndPoint, Core.Packets.Peerbloom.VersionPacket> Versions;
         public ConcurrentDictionary<IPEndPoint, Core.Packets.Peerbloom.VersionPacket> BadVersions;
         public ConcurrentDictionary<long, Coin.Block> BlockCache;
+        public ConcurrentDictionary<long, Coin.BlockHeader> HeaderCache;
 
         public ConcurrentDictionary<Cipher.SHA256, Coin.Block> OrphanBlocks;
 
@@ -42,6 +43,7 @@ namespace Discreet.Network
             BadVersions = new ConcurrentDictionary<IPEndPoint, Core.Packets.Peerbloom.VersionPacket>();
             BlockCache = new ConcurrentDictionary<long, Coin.Block>();
             OrphanBlocks = new ConcurrentDictionary<Cipher.SHA256, Coin.Block>();
+            HeaderCache = new ConcurrentDictionary<long, Coin.BlockHeader>();
         }
     }
 }

--- a/Discreet/Network/MessageCache.cs
+++ b/Discreet/Network/MessageCache.cs
@@ -31,6 +31,8 @@ namespace Discreet.Network
         public ConcurrentDictionary<IPEndPoint, Core.Packets.Peerbloom.VersionPacket> BadVersions;
         public ConcurrentDictionary<long, Coin.Block> BlockCache;
         public ConcurrentDictionary<long, Coin.BlockHeader> HeaderCache;
+        private long _headerMin = -1;
+        private long _headerMax = -1;
 
         public ConcurrentDictionary<Cipher.SHA256, Coin.Block> OrphanBlocks;
 
@@ -44,6 +46,34 @@ namespace Discreet.Network
             BlockCache = new ConcurrentDictionary<long, Coin.Block>();
             OrphanBlocks = new ConcurrentDictionary<Cipher.SHA256, Coin.Block>();
             HeaderCache = new ConcurrentDictionary<long, Coin.BlockHeader>();
+        }
+
+        public Queue<Coin.BlockHeader> PopHeaders(long max)
+        {
+            if (_headerMin == -1)
+            {
+                _headerMin = HeaderCache.Keys.Min();
+            }
+
+            if (_headerMax == -1)
+            {
+                _headerMax = HeaderCache.Keys.Max();
+            }
+
+            Queue<Coin.BlockHeader> headers = new();
+            for (long i = _headerMin; i < _headerMin + max && i <= _headerMax; i++)
+            {
+                var success = HeaderCache.Remove(i, out var header);
+                if (!success)
+                {
+                    Daemon.Logger.Warn($"MessageCache.PopHeaders: missing header found; error in header syncing");
+                }
+
+                headers.Enqueue(header);
+                _headerMin++;
+            }
+
+            return headers;
         }
     }
 }

--- a/Discreet/Network/Peerbloom/Feeler.cs
+++ b/Discreet/Network/Peerbloom/Feeler.cs
@@ -50,7 +50,7 @@ namespace Discreet.Network.Peerbloom
         {
             Daemon.Logger.Debug($"Feeler.Feel: testing peer {p.Endpoint}...");
             
-            Connection conn = new Connection(p.Endpoint, _network, _network.LocalNode);
+            Connection conn = new Connection(p.Endpoint, _network, _network.LocalNode, _peer: p);
 
             bool success = await conn.Connect(false, token, true);
 
@@ -110,7 +110,7 @@ namespace Discreet.Network.Peerbloom
 
                 while (timer > DateTime.UtcNow.Ticks && !token.IsCancellationRequested)
                 {
-                    await Task.Delay(500);
+                    await Task.Delay(500, token);
                 }
 
                 if (token.IsCancellationRequested) return;
@@ -134,9 +134,9 @@ namespace Discreet.Network.Peerbloom
                     if ((peer.LastAttempt + 10_000_000L * 3600L) > DateTime.UtcNow.Ticks) { tried++; continue; }
 
                     selected.Add(peer);
-                    _ = Task.Run(() => Feel(peer, token)).ConfigureAwait(false);
+                    _ = Task.Run(() => Feel(peer, token), token).ConfigureAwait(false);
 
-                    await Task.Delay(100);
+                    await Task.Delay(100, token);
                 }
             }
         }

--- a/Discreet/Network/Peerbloom/Network.cs
+++ b/Discreet/Network/Peerbloom/Network.cs
@@ -537,7 +537,7 @@ namespace Discreet.Network.Peerbloom
 
                     Connection conn = new Connection(node, this, LocalNode, true);
 
-                    bool success = await conn.Connect(true, _shutdownTokenSource.Token, false, 5000, 1);
+                    bool success = await conn.Connect(true, _shutdownTokenSource.Token, false, 5000, 2);
                     peerlist.Attempt(node, !success);
 
                     if (success) numConnected++;
@@ -545,8 +545,9 @@ namespace Discreet.Network.Peerbloom
                     checkedPeers.Add(node);
                     if (numConnected == 0 && endpoints.Count == checkedPeers.Count && !success)
                     {
-                        Daemon.Logger.Warn("Could not find any online/valid peers. Increasing timeout length and allowed attempts.");
-                        checkedPeers.Clear();
+                        Daemon.Logger.Warn("Could not find any online/valid peers. Restarting bootstrap.");
+                        await Bootstrap();
+                        return;
                     }
                 }
             }

--- a/Discreet/Network/Peerbloom/PeerExchanger.cs
+++ b/Discreet/Network/Peerbloom/PeerExchanger.cs
@@ -24,7 +24,7 @@ namespace Discreet.Network.Peerbloom
 
                 while (timer > DateTime.UtcNow.Ticks && !token.IsCancellationRequested)
                 {
-                    await Task.Delay(500);
+                    await Task.Delay(500, token);
                 }
 
                 if (token.IsCancellationRequested) return;

--- a/Discreet/Network/Peerbloom/Peerlist.cs
+++ b/Discreet/Network/Peerbloom/Peerlist.cs
@@ -341,7 +341,7 @@ namespace Discreet.Network.Peerbloom
             return addrs[nID];
         }
 
-        public bool AddNew(IPEndPoint endpoint, IPEndPoint source, long penalty)
+        public bool AddNew(IPEndPoint endpoint, IPEndPoint source, long penalty, long timestamp = -1)
         {
             if (endpoint.Equals(source))
             {
@@ -353,7 +353,14 @@ namespace Discreet.Network.Peerbloom
 
             if (pinfo != null)
             {
-                pinfo.LastSeen = DateTime.UtcNow.Ticks - penalty;
+                if (timestamp < 0)
+                {
+                    pinfo.LastSeen = DateTime.UtcNow.Ticks - penalty;
+                }
+                else
+                {
+                    pinfo.LastSeen = timestamp - penalty;
+                }
 
                 // make it harder to randomly add duplicate
                 int factor = 1;
@@ -370,7 +377,15 @@ namespace Discreet.Network.Peerbloom
             {
                 Daemon.Logger.Debug($"Peerlist.AddNew: adding {endpoint}");
                 pinfo = Create(endpoint, source, out nID);
-                pinfo.LastSeen = DateTime.UtcNow.Ticks - penalty;
+                if (timestamp < 0)
+                {
+                    pinfo.LastSeen = DateTime.UtcNow.Ticks - penalty;
+                }
+                else
+                {
+                    pinfo.LastSeen = timestamp - penalty;
+                }
+                pinfo.FirstSeen = DateTime.UtcNow.Ticks; // we keep track of this internally
                 _newCounter++;
             }
 
@@ -538,6 +553,10 @@ namespace Discreet.Network.Peerbloom
             if (countFailure)
             {
                 peer.NumFailedConnectionAttempts++;
+            }
+            else
+            {
+                peer.LastSuccess = DateTime.UtcNow.Ticks;
             }
         }
 


### PR DESCRIPTION
- bootstrap behavior change: peer tries to connect to two connections received from bootstrap node before proceeding
- if it cannot connect to two peers, it restarts the bootstrap process
- Add GetHeaders and Headers packets for header-first syncing
- Add header cache to message cache
- Add handlers for Headers and GetHeaders
- all request packets (GetBlocks, GetTxs, GetHeaders) now get registered to the handler
  - Handler now detects if an unsolicited response to these packets is received
  - Handler ensures that each packet received from each peer as a response to these fulfills an associated request
  - Designed to work in an asynchronous environment and split among multiple responses
  - Each request has an associated timeout and callback on either failure or success
- Header-first syncing is performed
  - Headers are retrieved in chunks of 25000 at a time
  - Headers are used to retrieve blocks by hash instead of height
  - Peers will continue to query on missed responses 