### PR TITLE
Patch/network fixes 1

### DIFF
--- a/Discreet/DB/ValidationCache.cs
+++ b/Discreet/DB/ValidationCache.cs
@@ -217,10 +217,20 @@ namespace Discreet.DB
                 /* check orphan data */
                 if (many)
                 {
-                    var pbsucc = blocksCache.TryGetValue(block.Header.PreviousBlock, out var prevBlock);
-                    if (!pbsucc || prevBlock == null) return new VerifyException("Block", "Could not get previous block");
-                    if (prevBlock.Header.Height + 1 != block.Header.Height) return new VerifyException("Block", "Previous block height + 1 does not equal block height");
-                    if (previousHeight + 1 != block.Header.Height) return new VerifyException("Block", "Chain height + 1 does not equal block height");
+                    if (blocksCache.Count == 0)
+                    {
+                        var pbsucc = dataView.TryGetBlockHeader(block.Header.PreviousBlock, out var prevBlockHeader);
+                        if (prevBlockHeader == null) return new VerifyException("Block", "Could not get previous block");
+                        if (prevBlockHeader.Height + 1 != block.Header.Height) return new VerifyException("Block", "Previous block height + 1 does not equal block height");
+                        if (previousHeight + 1 != block.Header.Height) return new VerifyException("Block", "Chain height + 1 does not equal block height");
+                    }
+                    else
+                    {
+                        var pbsucc = blocksCache.TryGetValue(block.Header.PreviousBlock, out var prevBlock);
+                        if (!pbsucc || prevBlock == null) return new VerifyException("Block", "Could not get previous block");
+                        if (prevBlock.Header.Height + 1 != block.Header.Height) return new VerifyException("Block", "Previous block height + 1 does not equal block height");
+                        if (previousHeight + 1 != block.Header.Height) return new VerifyException("Block", "Chain height + 1 does not equal block height");
+                    }
                 }
                 else
                 {

--- a/Discreet/Network/Peerbloom/Connection.cs
+++ b/Discreet/Network/Peerbloom/Connection.cs
@@ -541,6 +541,12 @@ namespace Discreet.Network.Peerbloom
                 /* receive RequestPeersResp */
                 Core.Packet resp = await ReadAsync(token);
 
+                while (resp != null && resp.Header.Command != Core.PacketType.REQUESTPEERSRESP)
+                {
+                    Daemon.Logger.Error($"Connection.RequestPeers: Received packet of type {resp.Header.Command}; skipping this and waiting for correct packet");
+                    resp = await ReadAsync(token);
+                }
+
                 if (resp == null)
                 {
                     throw new Exception("response was null");

--- a/Discreet/Network/Peerbloom/Network.cs
+++ b/Discreet/Network/Peerbloom/Network.cs
@@ -575,9 +575,12 @@ namespace Discreet.Network.Peerbloom
             {
                 foreach (var conn in InboundConnectedPeers.Values)
                 {
-                    Daemon.Logger.Debug($"Network.Broadcast: broadcasting to peer {conn.Receiver}");
-                    conn.Send(packet);
-                    i++;
+                    if (conn.ConnectionAcknowledged)
+                    {
+                        Daemon.Logger.Debug($"Network.Broadcast: broadcasting to peer {conn.Receiver}");
+                        conn.Send(packet);
+                        i++;
+                    }
                 }
             }
 


### PR DESCRIPTION
- fix minor bug with ValidationCache where it did not fetch first previous block when validating many blocks
- fix Connect.RequestPeers (changed behavior; now skips any unwanted packets until the requested packet arrives)
- broadcast to IncomingPeers only when they are acknowledged/validated