### PR TITLE
various fixes

### DIFF
--- a/Discreet/Daemon/DaemonConfig.cs
+++ b/Discreet/Daemon/DaemonConfig.cs
@@ -192,6 +192,11 @@ namespace Discreet.Daemon
                 NetConfig = new NetworkConfig();
             }
 
+            if (DbgConfig == null)
+            {
+                DbgConfig = new DebugConfig();
+            }
+
             if (APISets == null)
             {
                 APISets = new List<string>(new string[]
@@ -248,6 +253,7 @@ namespace Discreet.Daemon
 
         public NetworkConfig NetConfig { get; set; }
 
+        public DebugConfig DbgConfig { get; set; }
         public List<string> APISets { get; set; }
 
         public DaemonConfig()
@@ -297,6 +303,7 @@ namespace Discreet.Daemon
             SigningKey = Cipher.KeyOps.GenerateSeckey().ToHex();
 
             NetConfig = new NetworkConfig();
+            DbgConfig = new DebugConfig();
 
             APISets = new List<string>(new string[]
             {

--- a/Discreet/Daemon/DebugConfig.cs
+++ b/Discreet/Daemon/DebugConfig.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discreet.Daemon
+{
+    public class DebugConfig
+    {
+        public bool? DebugMode { get; set; }
+        public bool? SkipSyncing {  get; set; }
+        public bool? CheckBlockchain { get; set; }
+
+        public DebugConfig()
+        {
+            DebugMode = false;
+            SkipSyncing = false;
+            CheckBlockchain = false;
+        }
+    }
+}

--- a/Discreet/Daemon/Logger.cs
+++ b/Discreet/Daemon/Logger.cs
@@ -95,7 +95,7 @@ namespace Discreet.Daemon
             }
         }
 
-        public static void Log(string msg, string lvl)
+        public static void Log(string msg, string lvl, bool save = true)
         {
             lock (writer_lock)
             {
@@ -103,40 +103,43 @@ namespace Discreet.Daemon
 
                 Logger logger = GetLogger();
 
-                logger.openLog.WriteLine(msg);
-                logger.openLog.Flush();
+                if (save)
+                {
+                    logger.openLog.WriteLine(msg);
+                    logger.openLog.Flush();
+                }
 
                 Console.WriteLine(msg);
             }
         }
 
-        public static void Info(string msg)
+        public static void Info(string msg, bool save = true)
         {
-            Log(msg, "INFO");
+            Log(msg, "INFO", save);
         }
 
-        public static void Warn(string msg)
+        public static void Warn(string msg, bool save = true)
         {
-            Log(msg, "WARN");
+            Log(msg, "WARN", save);
         }
 
-        public static void Error(string msg, Exception exc = null)
+        public static void Error(string msg, Exception exc = null, bool save = true)
         {
             if (exc != null && DaemonConfig.GetConfig().PrintStackTraces.Value)
-                Log($"{msg}\nStack Trace:\n{exc.StackTrace}", "ERROR");
+                Log($"{msg}\nStack Trace:\n{exc.StackTrace}", "ERROR", save);
             else
-                Log(msg, "ERROR");
+                Log(msg, "ERROR", save);
         }
 
-        public static void Fatal(string msg)
+        public static void Fatal(string msg, bool save = true)
         {
-            Log(msg, "FATAL");
+            Log(msg, "FATAL", save);
         }
 
-        public static void Debug(string msg)
+        public static void Debug(string msg, bool save = true)
         {
             if (Daemon.DebugMode)
-                Log(msg, "DEBUG");
+                Log(msg, "DEBUG", save);
         }
     }
 }

--- a/Discreet/Network/Handler.cs
+++ b/Discreet/Network/Handler.cs
@@ -854,7 +854,7 @@ namespace Discreet.Network
                     Count = p.Count,
                     Inventory = notFound.ToArray(),
                 };
-                
+
                 Peerbloom.Network.GetNetwork().Send(senderEndpoint, new Packet(PacketType.NOTFOUND, resp));
             }
         }
@@ -1089,7 +1089,6 @@ namespace Discreet.Network
                         if (!MessageCache.GetMessageCache().OrphanBlockParents.ContainsKey(p.Block.Header.PreviousBlock))
                         {
                             Daemon.Logger.Warn($"HandleSendBlock: orphan block ({p.Block.Header.BlockHash.ToHexShort()}, height {p.Block.Header.Height}) added; querying {conn.Receiver} for previous block");
-
                             MessageCache.GetMessageCache().OrphanBlocks[p.Block.Header.PreviousBlock] = p.Block;
                             MessageCache.GetMessageCache().OrphanBlockParents[p.Block.Header.BlockHash] = 0;
                             Peerbloom.Network.GetNetwork().SendRequest(conn, new Packet(PacketType.GETBLOCKS, new GetBlocksPacket { Blocks = new Cipher.SHA256[] { p.Block.Header.PreviousBlock }, Count = 1 }), durationMilliseconds: 60000);
@@ -1098,7 +1097,9 @@ namespace Discreet.Network
                         else
                         {
                             Daemon.Logger.Warn($"HandleSendBlock: orphan block ({p.Block.Header.BlockHash.ToHexShort()}, height {p.Block.Header.Height}) added");
-
+                            MessageCache.GetMessageCache().OrphanBlocks[p.Block.Header.PreviousBlock] = p.Block;
+                            MessageCache.GetMessageCache().OrphanBlockParents[p.Block.Header.BlockHash] = 0;
+                            return;
                         }
                     }
                     else if (err != null)
@@ -1217,6 +1218,9 @@ namespace Discreet.Network
                         else
                         {
                             Daemon.Logger.Warn($"HandleBlocks: orphan block ({p.Blocks[0].Header.BlockHash.ToHexShort()}, height {p.Blocks[0].Header.Height}) added");
+                            MessageCache.GetMessageCache().OrphanBlocks[p.Blocks[0].Header.PreviousBlock] = p.Blocks[0];
+                            MessageCache.GetMessageCache().OrphanBlockParents[p.Blocks[0].Header.BlockHash] = 0;
+                            return;
                         }
                     }
                     else if (err != null)

--- a/Discreet/Network/MessageCache.cs
+++ b/Discreet/Network/MessageCache.cs
@@ -35,7 +35,7 @@ namespace Discreet.Network
         private long _headerMax = -1;
 
         public ConcurrentDictionary<Cipher.SHA256, Coin.Block> OrphanBlocks;
-        public ConcurrentDictionary<Cipher.SHA256, int> OrphanBlockParents = new();
+        public ConcurrentDictionary<Cipher.SHA256, int> OrphanBlockParents = new(new Cipher.SHA256EqualityComparer());
 
         public MessageCache()
         {
@@ -130,8 +130,11 @@ namespace Discreet.Network
             }
 
             Queue<Coin.BlockHeader> headers = new();
-            for (long i = _headerMin; i < _headerMin + max && i <= _headerMax; i++)
+            var maxHeight = _headerMin + max;
+            for (long i = _headerMin; i < maxHeight; i++)
             {
+                if (i > _headerMax) break;
+
                 var success = HeaderCache.Remove(i, out var header);
                 if (!success)
                 {

--- a/Discreet/Network/Peerbloom/Feeler.cs
+++ b/Discreet/Network/Peerbloom/Feeler.cs
@@ -104,6 +104,11 @@ namespace Discreet.Network.Peerbloom
 
         public async Task Start(CancellationToken token)
         {
+            while (!token.IsCancellationRequested && (Handler.GetHandler() == null || Handler.GetHandler().State != PeerState.Normal))
+            {
+                await Task.Delay(500, token);
+            }
+
             while (!token.IsCancellationRequested)
             {
                 var timer = DateTime.UtcNow.AddSeconds(Constants.PEERBLOOM_FEELER_INTERVAL).Ticks;

--- a/Discreet/Network/Peerbloom/Heartbeater.cs
+++ b/Discreet/Network/Peerbloom/Heartbeater.cs
@@ -18,6 +18,11 @@ namespace Discreet.Network.Peerbloom
 
         public async Task Heartbeat(CancellationToken token)
         {
+            while (!token.IsCancellationRequested && (Handler.GetHandler() == null || Handler.GetHandler().State != PeerState.Normal))
+            {
+                await Task.Delay(500, token);
+            }
+
             while (!token.IsCancellationRequested)
             {
                 var timer = DateTime.UtcNow.AddSeconds(Constants.PEERBLOOM_HEARTBEATER).Ticks;

--- a/Discreet/Program.cs
+++ b/Discreet/Program.cs
@@ -1105,9 +1105,10 @@ namespace Discreet
 				w.Decrypt(passphrase);
 			}*/
 
-			Daemon.Daemon.DebugMode = true;
+			//Daemon.Daemon.DebugMode = true;
 
 			var config = Daemon.DaemonConfig.GetConfig();
+			Daemon.Daemon.DebugMode = config.DbgConfig.DebugMode.Value;
 
 			//Console.Write("Bootstrap IP: ");
 			//IPAddress bootstrapIP = IPAddress.Parse(Console.ReadLine());


### PR DESCRIPTION
- Add DebugConfig structure to DaemonConfig
- Add debugmode boolean to DebugConfig, set Daemon.DebugMode to this value
- Add SkipSyncing boolean to DebugConfig, if true, skips syncing code section in Daemon.Start()
- Add CheckBlockchain boolean to DebugConfig, if true, after daemon syncing it checks if all blocks are present in the blockchain
- Add save parameter to Logger methods to control if a statement should be logged to the logfile or just printed to stdout (default: true)
- Fix bugs with Feeler/Heartbeater causing errors on startup
- Fix bug where orphan blocks would lead to inconsistent state
- Fix bug where syncer fails after first request