### PR TITLE
various fixes

### DIFF
--- a/Discreet/DB/ArchiveDB.cs
+++ b/Discreet/DB/ArchiveDB.cs
@@ -126,6 +126,11 @@ namespace Discreet.DB
             }
         }
 
+        /// <summary>
+        /// <warn>DEPRACATED</warn>
+        /// </summary>
+        /// <param name="blk"></param>
+        /// <exception cref="Exception"></exception>
         public void AddBlockToCache(Block blk)
         {
             lock (block_cache_lock)

--- a/Discreet/Network/Core/Packets/InventoryVector.cs
+++ b/Discreet/Network/Core/Packets/InventoryVector.cs
@@ -37,25 +37,19 @@ namespace Discreet.Network.Core.Packets
             return tcmp;
         }
 
+        public override bool Equals([NotNullWhen(true)] object obj)
+        {
+            if (obj == null) return false;
+            if (obj is InventoryVector b) return Type == b.Type && Hash.Bytes.BEquals(b.Hash.Bytes);
+            return false;
+        }
+
         public static bool operator ==(InventoryVector x, InventoryVector y) => x.Type == y.Type && x.Hash.Bytes.BEquals(y.Hash.Bytes);
         public static bool operator !=(InventoryVector x, InventoryVector y) => !(x == y);
-    }
 
-    public class InventoryVectorComparer : IComparer<InventoryVector>
-    {
-        public int Compare(InventoryVector x, InventoryVector y)
+        public override int GetHashCode()
         {
-            return x.Compare(y);
-        }
-
-        public bool Equals(InventoryVector x, InventoryVector y)
-        {
-            return x == y;
-        }
-
-        public int GetHashCode([DisallowNull] InventoryVector obj)
-        {
-            return Coin.Serialization.GetInt32(Cipher.SHA256.HashData(obj.Serialize()).Bytes, 0);
+            return Coin.Serialization.GetInt32(Hash.Bytes, 28);
         }
     }
 }

--- a/Discreet/Network/Peerbloom/Connection.cs
+++ b/Discreet/Network/Peerbloom/Connection.cs
@@ -379,7 +379,7 @@ namespace Discreet.Network.Peerbloom
                                 return false;
                             }
 
-                            IsPersistent = !feeler;
+                            IsPersistent = feeler ? false : persist;
                             ConnectionAcknowledged = true;
                             LastValidReceive = DateTime.UtcNow.Ticks;
                             LastValidSend = DateTime.UtcNow.Ticks;
@@ -413,7 +413,7 @@ namespace Discreet.Network.Peerbloom
                         return false;
                     }
 
-                    if (!feeler)
+                    if (!feeler && persist)
                     {
                         _network.AddOutboundConnection(this);
                     }

--- a/Discreet/Network/Peerbloom/Constants.cs
+++ b/Discreet/Network/Peerbloom/Constants.cs
@@ -46,7 +46,7 @@ namespace Discreet.Network.Peerbloom
         /// <summary>
         /// The time in milliseconds to timeout a single read operation.
         /// </summary>
-        public const int CONNECTION_READ_TIMEOUT = 10000;
+        public const int CONNECTION_READ_TIMEOUT = 30000;
 
         /// <summary>
         /// The maximum number of outbound connections allowed by the network.

--- a/Discreet/Network/Peerbloom/Network.cs
+++ b/Discreet/Network/Peerbloom/Network.cs
@@ -555,7 +555,7 @@ namespace Discreet.Network.Peerbloom
                     }
                 }
             }
-            while (numBootstrapFailures < Constants.NUM_BOOTSTRAP_ALLOWED_FAILURES);
+            while (numBootstrapFailures < Constants.NUM_BOOTSTRAP_ALLOWED_FAILURES && OutboundConnectedPeers.Count == 0);
 
             if (Daemon.Daemon.DebugMode || numBootstrapFailures >= Constants.NUM_BOOTSTRAP_ALLOWED_FAILURES)
             {
@@ -563,6 +563,12 @@ namespace Discreet.Network.Peerbloom
                 peerlist.Create(bootstrapNode.Receiver, bootstrapNode.Receiver, out _);
                 peerlist.Good(bootstrapNode.Receiver, false);
                 _ = Task.Run(() => bootstrapNode.Persistent(_shutdownTokenSource.Token)).ConfigureAwait(false);
+            }
+            
+            // if we are connected to at least two other nodes, then the bootstrap was successful and we can disconnect.
+            if (OutboundConnectedPeers.Count >= 2)
+            {
+                await bootstrapNode.Disconnect(true, Core.Packets.Peerbloom.DisconnectCode.CLEAN);
             }
 
             IsBootstrapping = false;


### PR DESCRIPTION
- remove unused code (AddBlockToCache) from database
- refactor Handler requests system
- speed up Handler requests system
- fix bug in Handler.RegisterNeeded()
- switch code to use MessageCache.AddBlockToCache()
- change delay in Handler's request timeout task to 30 seconds
- fix IsPersistent and AddOutboundConnection rules for Connection.Connect()
- use a persistent connection to the bootstrap node for startup; disconnect on successful startup (>=2 peers)
  - lazily use bootstrap node as default peer in this manner
- ignore SENDTX and SENDBLOCK messages during startup